### PR TITLE
Support Jekyll/frontmatter style YAML

### DIFF
--- a/yamdl/loader.py
+++ b/yamdl/loader.py
@@ -88,6 +88,9 @@ class ModelLoader(object):
             yaml_data = ""
             for line in fh:
                 if line.strip() == "---":
+                    if not yaml_data:
+                        # File started with "---"
+                        continue
                     break
                 else:
                     yaml_data += line


### PR DESCRIPTION
Jekyll and python-frontmatter assume that the file will start with `---`. Closes #5.