### PR TITLE
Use constant for supported extensions

### DIFF
--- a/yamdl/apps.py
+++ b/yamdl/apps.py
@@ -60,5 +60,7 @@ class YamdlConfig(AppConfig):
 
     def autoreload_ready(self, sender, **kwargs):
         for directory in settings.YAMDL_DIRECTORIES:
-            sender.watch_dir(directory, "**/*.yaml")
-            sender.watch_dir(directory, "**/*.md")
+            for ext in self.loader.EXT_MARKDOWN:
+                sender.watch_dir(directory, f"**/*{ext}")
+            for ext in self.loader.EXT_YAML:
+                sender.watch_dir(directory, f"**/*{ext}")

--- a/yamdl/loader.py
+++ b/yamdl/loader.py
@@ -10,6 +10,9 @@ class ModelLoader(object):
     a database (designed for an in-memory one due to PK removal etc.)
     """
 
+    EXT_MARKDOWN = [".md", ".markdown"]
+    EXT_YAML = [".yml", ".yaml"]
+
     def __init__(self, connection, directories):
         self.connection = connection
         self.directories = directories
@@ -42,9 +45,9 @@ class ModelLoader(object):
         for filename in folder_path.iterdir():
             if filename.is_dir():
                 self.load_folder_files(model_name, filename)
-            elif filename.suffix in [".yml", ".yaml"] and filename.is_file():
+            elif filename.suffix in self.EXT_YAML and filename.is_file():
                 self.load_yaml_file(model_name, filename)
-            elif filename.suffix in [".md", ".markdown"] and filename.is_file():
+            elif filename.suffix in self.EXT_MARKDOWN and filename.is_file():
                 self.load_markdown_file(model_name, filename)
 
     def get_model_class(self, model_name):


### PR DESCRIPTION
ModelLoader was updated to support multiple extensions but the corresponding watch code in YamdlConfig.autoreload_ready also needs to watch for the same extensions.

I'm not sure if a class property is better than a module property or not. Do you have any thoughts or preferences?