### PR TITLE
Reduce verbosity

### DIFF
--- a/yamdl/apps.py
+++ b/yamdl/apps.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -53,8 +54,13 @@ class YamdlConfig(AppConfig):
                     )
             # Read the fixtures into memory
             self.loader = ModelLoader(self.connection, settings.YAMDL_DIRECTORIES)
-            self.loader.load()
+            with warnings.catch_warnings():
+                # Django doesn't like running DB queries during app initialization
+                warnings.filterwarnings("ignore", module="django.db", category=RuntimeError)
+                self.loader.load()
+
             self.loaded = True
+
             # Add autoreload watches for our files
             autoreload_started.connect(self.autoreload_ready)
 

--- a/yamdl/loader.py
+++ b/yamdl/loader.py
@@ -6,6 +6,7 @@ from django.apps import apps
 
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class ModelLoader(object):
@@ -39,7 +40,7 @@ class ModelLoader(object):
                     model = self.managed_directories[model_folder.name]
                     # Second level should be files, or more folders
                     self.load_folder_files(model._meta.label_lower, model_folder)
-        logger.debug("Loaded %d yamdl fixtures.", self.loaded)
+        logger.info("Loaded %d yamdl fixtures.", self.loaded)
 
     def load_folder_files(self, model_name, folder_path: Path):
         """
@@ -143,4 +144,4 @@ class ModelLoader(object):
         with self.connection.schema_editor() as editor:
             for model in self.managed_models.values():
                 editor.create_model(model)
-        logger.debug("Created yamdl schema for %s" % (", ".join(self.managed_models.keys()),))
+        logger.info("Created yamdl schema for %s" % (", ".join(self.managed_models.keys()),))

--- a/yamdl/loader.py
+++ b/yamdl/loader.py
@@ -1,7 +1,11 @@
+import logging
 from pathlib import Path
 
 import yaml
 from django.apps import apps
+
+
+logger = logging.getLogger(__name__)
 
 
 class ModelLoader(object):
@@ -35,8 +39,7 @@ class ModelLoader(object):
                     model = self.managed_directories[model_folder.name]
                     # Second level should be files, or more folders
                     self.load_folder_files(model._meta.label_lower, model_folder)
-        # Print result
-        print("Loaded %s yamdl fixtures." % self.loaded)
+        logger.debug("Loaded %d yamdl fixtures.", self.loaded)
 
     def load_folder_files(self, model_name, folder_path: Path):
         """
@@ -140,4 +143,4 @@ class ModelLoader(object):
         with self.connection.schema_editor() as editor:
             for model in self.managed_models.values():
                 editor.create_model(model)
-        print("Created yamdl schema for %s" % (", ".join(self.managed_models.keys()),))
+        logger.debug("Created yamdl schema for %s" % (", ".join(self.managed_models.keys()),))


### PR DESCRIPTION
During server startup, quite a few messages can be printed, which pollutes log output.

This PR makes 2 changes:

- Suppress a log from `django` about trying to access the DB before apps are ready. Targetting specific warnings is quite difficult, but hopefully this is good enough without overcomplicating it.
- Replace `print` for `logging`, so is is user-controllable