### PR TITLE
Allow log level to be overriden

### DIFF
--- a/yamdl/loader.py
+++ b/yamdl/loader.py
@@ -6,7 +6,6 @@ from django.apps import apps
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class ModelLoader(object):


### PR DESCRIPTION
To ensure `yamdl` logs are shown, add an entry for it to `LOGGING` setting.

This works fine when not configuring logging at all (ie not calling `logging.basicConfig`), but when `logging` is configured it's stuck in `INFO` and can't be changed.

Andrew, I know you like seeing the logs, but hopefully just adding a `LOGGING` config entry for it is an ok enough compromise? :slightly_smiling_face: 