### PR TITLE
fix: Fix load_folder_files and use model._meta.label for __yamdl_directory__ default

### DIFF
--- a/yamdl/loader.py
+++ b/yamdl/loader.py
@@ -58,7 +58,7 @@ class ModelLoader(object):
 
         for filename in folder_path.iterdir():
             if filename.is_dir():
-                self.load_folder_files(model_class, filename)
+                self.load_folder_files(model_name, filename)
             elif filename.suffix in self.EXT_YAML and filename.is_file():
                 self.load_yaml_file(model_class, filename)
             elif filename.suffix in self.EXT_MARKDOWN and filename.is_file():
@@ -144,7 +144,7 @@ class ModelLoader(object):
         for app in apps.get_app_configs():
             for model in app.get_models():
                 if getattr(model, "__yamdl__", False):
-                    directory = getattr(model, "__yamdl_directory__", model._meta.label_lower)
+                    directory = getattr(model, "__yamdl_directory__", model._meta.label)
                     self.managed_models[model._meta.label_lower] = model
                     self.managed_directories[directory] = model
         # Make the tables in the database


### PR DESCRIPTION
Pass model_name to ModelLoader.load_folder_files in recursive call instead of model_class.
Use model._meta.label for the default value of __yamdl_directory__.