### PR TITLE
Use class_prepared signal for loading fixtures

### DIFF
--- a/yamdl/apps.py
+++ b/yamdl/apps.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 from django.utils.autoreload import autoreload_started
+from django.db.models.signals import class_prepared
 from django.utils.module_loading import import_string
 
 from .loader import ModelLoader
@@ -20,6 +21,9 @@ class YamdlConfig(AppConfig):
         """
         Startup and signal handling code
         """
+        class_prepared.connect(self.populate_models, dispatch_uid="yamdl-populate-models")
+
+    def populate_models(self, **kwargs):
         if not self.loaded:
             # Verify we have a db alias to write to.
             self.db_alias = getattr(settings, "YAMDL_DATABASE_ALIAS", "yamdl")


### PR DESCRIPTION
If we do all of our loading in AppConfig.ready, then it runs before the normal Django checks framework. This means that errors in our app models throw a stack trace instead of a more detailed message if there is a problem with our schema. By moving our schema loading to a signal, we can insure that the checks framework runs first.

It's possible some of the other checks for ImproperlyConfigured could be
 moved to the checks framework in a future PR.


I triggered this when I had an error with my class model that I forgot to add max_length to.

```python
class Post(models.Model):
    __yamdl__ = True

    title = models.CharField(max_length=128) # Fine
    other = models.CharField() # Missing max_length, would be caught by checks framework
```